### PR TITLE
Fix ESLint parsing for TypeScript

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,12 +1,22 @@
 // eslint.config.mjs
 
 import prettierPlugin from "eslint-plugin-prettier";
+import tseslint from "@typescript-eslint/eslint-plugin";
+import tsParser from "@typescript-eslint/parser";
 
 export default [
   {
     files: ['**/*.{ts,tsx}'],
+    languageOptions: {
+      parser: tsParser,
+      parserOptions: {
+        project: './tsconfig.json',
+        tsconfigRootDir: new URL('.', import.meta.url).pathname,
+      },
+    },
     plugins: {
       prettier: prettierPlugin,
+      '@typescript-eslint': tseslint,
     },
     rules: {
       "prettier/prettier": ["error", {}, { usePrettierrc: true }]

--- a/package.json
+++ b/package.json
@@ -31,6 +31,8 @@
     "eslint-config-prettier": "^10.1.1",
     "eslint-plugin-import": "^2.31.0",
     "eslint-plugin-prettier": "^5.2.3",
+    "@typescript-eslint/eslint-plugin": "^7.5.0",
+    "@typescript-eslint/parser": "^7.5.0",
     "file-loader": "^6.2.0",
     "gh-pages": "^6.1.1",
     "html-webpack-plugin": "^5.6.3",


### PR DESCRIPTION
## Summary
- configure ESLint to parse TypeScript files
- add required TypeScript ESLint packages

## Testing
- `npm run lint` *(fails: Cannot find package 'eslint-plugin-prettier' because dependencies aren't installed)*

------
https://chatgpt.com/codex/tasks/task_e_68455468f4c083288b84f0d71e9bfe25